### PR TITLE
fix: undefine noreturn macro in object.h

### DIFF
--- a/core/object.h
+++ b/core/object.h
@@ -2,6 +2,13 @@
 #define LVGL_CPP_CORE_OBJECT_H_
 
 #include <cstdint>
+
+// Fix for 'noreturn' macro collision from C headers (e.g. stdnoreturn.h
+// included by LVGL)
+#if defined(noreturn)
+#undef noreturn
+#endif
+
 #include <functional>
 #include <memory>
 


### PR DESCRIPTION
Un-defines the `noreturn` macro (if present) before including C++ standard headers in `object.h` to prevent macro collisions with `[[noreturn]]` attributes in strict C++ environments (e.g. Clang). Fixes issue #29.