### PR TITLE
chore: update lvgl dependency to ^9.4

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,2 +1,2 @@
 dependencies:
-  lvgl/lvgl: "^9.0"
+  lvgl/lvgl: "^9.4"


### PR DESCRIPTION
Updates idf_component.yml to depend on lvgl/lvgl ^9.4. Fixes #40.