### PR TITLE
fix(widgets): correct include path for enums.h

### DIFF
--- a/widgets/slider.h
+++ b/widgets/slider.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-#include "../../misc/enums.h"
+#include "../misc/enums.h"
 #include "bar.h"   // IWYU pragma: export
 #include "lvgl.h"  // IWYU pragma: export
 

--- a/widgets/spinbox.h
+++ b/widgets/spinbox.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-#include "../../misc/enums.h"
+#include "../misc/enums.h"
 #include "lvgl.h"      // IWYU pragma: export
 #include "textarea.h"  // IWYU pragma: export
 


### PR DESCRIPTION
Fixed incorrect relative include paths for enums.h in slider.h and spinbox.h.