### PR TITLE
feat(font): add OwnedFont for runtime font management (#65)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES
     core/style.cpp
     misc/color.cpp
     font/font.cpp
+    font/owned_font.cpp
     misc/file_system.cpp
     core/observer.cpp
     draw/image_decoder.cpp
@@ -248,6 +249,10 @@ add_test(NAME test_menu COMMAND test_menu)
     add_test(NAME test_screen COMMAND test_screen)
     add_test(NAME test_callbacks COMMAND test_callbacks)
     add_test(NAME test_input_device COMMAND test_input_device)
+
+    add_executable(test_font tests/test_font.cpp font/font.cpp font/owned_font.cpp core/object.cpp misc/timer.cpp)
+    target_link_libraries(test_font PRIVATE lvgl_cpp)
+    add_test(NAME test_font COMMAND test_font)
 
     # Header Integrity Check (Regression test for self-contained headers)
     find_package(Python3 REQUIRED)

--- a/font/font.h
+++ b/font/font.h
@@ -42,7 +42,7 @@ class Font {
   static const Font& montserrat_30();
   static const Font& montserrat_32();
 
- private:
+ protected:
   const lv_font_t* font_;
 };
 

--- a/font/owned_font.cpp
+++ b/font/owned_font.cpp
@@ -1,0 +1,42 @@
+#include "owned_font.h"
+
+#include <utility>
+
+namespace lvgl {
+
+OwnedFont::OwnedFont() : Font(nullptr) {}
+
+OwnedFont::OwnedFont(lv_font_t* font) : Font(font) {}
+
+OwnedFont::OwnedFont(OwnedFont&& other) noexcept : Font(other.font_) {
+  // Take ownership, clear source
+  other.font_ = nullptr;
+}
+
+OwnedFont& OwnedFont::operator=(OwnedFont&& other) noexcept {
+  if (this != &other) {
+    destroy();
+    font_ = other.font_;
+    other.font_ = nullptr;
+  }
+  return *this;
+}
+
+OwnedFont::~OwnedFont() { destroy(); }
+
+void OwnedFont::destroy() {
+  if (font_) {
+    // Cast away constness because lv_binfont_destroy takes non-const pointer
+    // This is safe because OwnedFont is created with ownership
+    lv_binfont_destroy(const_cast<lv_font_t*>(font_));
+    font_ = nullptr;
+  }
+}
+
+OwnedFont OwnedFont::load_bin(const std::string& path) {
+  // lv_binfont_create returns a new font object or NULL on failure
+  lv_font_t* f = lv_binfont_create(path.c_str());
+  return OwnedFont(f);
+}
+
+}  // namespace lvgl

--- a/font/owned_font.h
+++ b/font/owned_font.h
@@ -1,0 +1,66 @@
+#ifndef LVGL_CPP_FONT_OWNED_FONT_H_
+#define LVGL_CPP_FONT_OWNED_FONT_H_
+
+#include <string>
+
+#include "font.h"
+#include "lvgl.h"
+
+namespace lvgl {
+
+/**
+ * @brief RAII wrapper for an owning lv_font_t.
+ * Manages the lifecycle of runtime-loaded fonts (e.g. from .bin or .ttf).
+ */
+class OwnedFont : public Font {
+ public:
+  /**
+   * @brief Construct an empty/invalid OwnedFont.
+   */
+  OwnedFont();
+
+  /**
+   * @brief Move constructor.
+   * Transfer ownership from other.
+   */
+  OwnedFont(OwnedFont&& other) noexcept;
+
+  /**
+   * @brief Move assignment.
+   */
+  OwnedFont& operator=(OwnedFont&& other) noexcept;
+
+  // Non-copyable
+  OwnedFont(const OwnedFont&) = delete;
+  OwnedFont& operator=(const OwnedFont&) = delete;
+
+  /**
+   * @brief Destructor.
+   * Destroys the font via lv_font_delete.
+   */
+  ~OwnedFont();
+
+  /**
+   * @brief Load a binary font from the filesystem.
+   * Wrapper for lv_binfont_create.
+   * @param path File path to the .bin font file.
+   * @return OwnedFont instance. Check is_valid() for success.
+   */
+  static OwnedFont load_bin(const std::string& path);
+
+  // TODO: Add load_tiny_ttf if TineTTF is enabled.
+
+ private:
+  /**
+   * @brief Private constructor taking ownership of a raw pointer.
+   * @param font Raw lv_font_t pointer created by LVGL.
+   */
+  explicit OwnedFont(lv_font_t* font);
+
+  // Helper to safely delete the managed font
+  void destroy();
+};
+
+}  // namespace lvgl
+
+#endif  // LVGL_CPP_FONT_OWNED_FONT_H_

--- a/tests/test_font.cpp
+++ b/tests/test_font.cpp
@@ -1,0 +1,35 @@
+#include <cassert>
+#include <iostream>
+
+#include "../font/owned_font.h"
+#include "lvgl.h"
+
+int main() {
+  lv_init();
+
+  std::cout << "Testing OwnedFont..." << std::endl;
+
+  // Test Move Semantics (with invalid font essentially)
+  {
+    lvgl::OwnedFont f1;
+    assert(!f1.is_valid());
+
+    lvgl::OwnedFont f2 = std::move(f1);
+    assert(!f2.is_valid());
+  }
+
+  // Test Load (Will fail but verify API linkage)
+  {
+    // Try loading a non-existent file. Should return invalid font (or null
+    // inner) Check lvgl log for error if enabled
+    lvgl::OwnedFont f = lvgl::OwnedFont::load_bin("non_existent_font.bin");
+    // lv_binfont_create returns NULL if failed
+    assert(!f.is_valid());
+    if (!f.is_valid()) {
+      std::cout << "Correctly handled missing font file." << std::endl;
+    }
+  }
+
+  std::cout << "[SUCCESS] OwnedFont basic lifecycle verified." << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Implemented OwnedFont RAII wrapper using lv_binfont_destroy. Verified with test_font.cpp.