### PR TITLE
feat: Integrate Scoped Enums and Fix Event Callback Safety

### DIFF
--- a/core/event.cpp
+++ b/core/event.cpp
@@ -4,7 +4,9 @@
 
 namespace lvgl {
 
-lv_event_code_t Event::get_code() const { return lv_event_get_code(evt_); }
+EventCode Event::get_code() const {
+  return static_cast<EventCode>(lv_event_get_code(evt_));
+}
 
 Object Event::get_target() const {
   return Object(static_cast<lv_obj_t*>(lv_event_get_target(evt_)),

--- a/core/event.h
+++ b/core/event.h
@@ -1,6 +1,7 @@
 #ifndef LVGL_CPP_CORE_EVENT_H_
 #define LVGL_CPP_CORE_EVENT_H_
 
+#include "../misc/enums.h"
 #include "lvgl.h"
 
 namespace lvgl {
@@ -17,7 +18,7 @@ class Event {
   /**
    * @brief Get the event code.
    */
-  lv_event_code_t get_code() const;
+  EventCode get_code() const;
 
   /**
    * @brief Get the original target of the event.

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -40,6 +40,8 @@ Object::~Object() {
     for (auto& node : callback_nodes_) {
       lv_obj_remove_event_cb_with_user_data(obj_, event_proxy, node.get());
     }
+    // Remove the internal delete hook to prevent use-after-free of 'this'
+    lv_obj_remove_event_cb_with_user_data(obj_, on_delete_event, this);
 
     if (owned_) {
       lv_obj_delete(obj_);
@@ -157,6 +159,10 @@ void Object::add_event_cb(lv_event_code_t event_code, EventCallback callback) {
   callback_nodes_.push_back(std::move(node));
 }
 
+void Object::add_event_cb(EventCode event_code, EventCallback callback) {
+  add_event_cb(static_cast<lv_event_code_t>(event_code), std::move(callback));
+}
+
 // --- Styles ---
 
 void Object::add_style(Style& style, lv_style_selector_t selector) {
@@ -199,6 +205,41 @@ void Object::set_style_image_recolor(lv_color_t value,
 void Object::set_style_bg_image_src(const void* value,
                                     lv_style_selector_t selector) {
   if (obj_) lv_obj_set_style_bg_image_src(obj_, value, selector);
+}
+
+// --- Layout & Scroll ---
+
+void Object::set_flex_flow(FlexFlow flow) {
+  if (obj_) lv_obj_set_flex_flow(obj_, static_cast<lv_flex_flow_t>(flow));
+}
+
+void Object::set_flex_align(FlexAlign main_place, FlexAlign cross_place,
+                            FlexAlign track_cross_place) {
+  if (obj_) {
+    lv_obj_set_flex_align(obj_, static_cast<lv_flex_align_t>(main_place),
+                          static_cast<lv_flex_align_t>(cross_place),
+                          static_cast<lv_flex_align_t>(track_cross_place));
+  }
+}
+
+void Object::set_grid_align(GridAlign column_align, GridAlign row_align) {
+  if (obj_) {
+    lv_obj_set_grid_align(obj_, static_cast<lv_grid_align_t>(column_align),
+                          static_cast<lv_grid_align_t>(row_align));
+  }
+}
+
+void Object::set_scrollbar_mode(ScrollbarMode mode) {
+  if (obj_)
+    lv_obj_set_scrollbar_mode(obj_, static_cast<lv_scrollbar_mode_t>(mode));
+}
+
+void Object::set_scroll_snap_x(ScrollSnap snap) {
+  if (obj_) lv_obj_set_scroll_snap_x(obj_, static_cast<lv_scroll_snap_t>(snap));
+}
+
+void Object::set_scroll_snap_y(ScrollSnap snap) {
+  if (obj_) lv_obj_set_scroll_snap_y(obj_, static_cast<lv_scroll_snap_t>(snap));
 }
 
 }  // namespace lvgl

--- a/core/object.h
+++ b/core/object.h
@@ -162,7 +162,49 @@ class Object {
    */
   bool is_valid() const { return obj_ != nullptr; }
 
-  // --- Flags& States ---
+  // --- Layout & Scroll ---
+
+  /**
+   * @brief Set the flex flow.
+   * @param flow The flex flow direction/wrap.
+   */
+  void set_flex_flow(FlexFlow flow);
+
+  /**
+   * @brief Set the flex alignment.
+   * @param main_place Main axis alignment.
+   * @param cross_place Cross axis alignment.
+   * @param track_cross_place Cross axis alignment of the tracks.
+   */
+  void set_flex_align(FlexAlign main_place, FlexAlign cross_place,
+                      FlexAlign track_cross_place);
+
+  /**
+   * @brief Set the grid alignment.
+   * @param column_align Column alignment.
+   * @param row_align Row alignment.
+   */
+  void set_grid_align(GridAlign column_align, GridAlign row_align);
+
+  /**
+   * @brief Set the scrollbar mode.
+   * @param mode The scrollbar mode.
+   */
+  void set_scrollbar_mode(ScrollbarMode mode);
+
+  /**
+   * @brief Set the horizontal scroll snap.
+   * @param snap The snap mode.
+   */
+  void set_scroll_snap_x(ScrollSnap snap);
+
+  /**
+   * @brief Set the vertical scroll snap.
+   * @param snap The snap mode.
+   */
+  void set_scroll_snap_y(ScrollSnap snap);
+
+  // --- Flags & States ---
 
   /**
    * @brief Add a flag to the object.
@@ -232,6 +274,13 @@ class Object {
    * @param callback The callable to execute.
    */
   void add_event_cb(lv_event_code_t event_code, EventCallback callback);
+
+  /**
+   * @brief Add a functional event callback (Scoped Enum).
+   * @param event_code The event code to listen for.
+   * @param callback The callable to execute.
+   */
+  void add_event_cb(EventCode event_code, EventCallback callback);
 
   // --- Styles ---
 

--- a/tests/test_enums.cpp
+++ b/tests/test_enums.cpp
@@ -2,8 +2,11 @@
 #include <iostream>
 
 #include "../display/display.h"
+#include "../widgets/arc.h"
+#include "../widgets/bar.h"
 #include "../widgets/button.h"
 #include "../widgets/label.h"
+#include "../widgets/slider.h"
 #include "lvgl.h"
 
 int main() {
@@ -12,14 +15,20 @@ int main() {
   // Create a display (required for screens)
   auto disp = lvgl::Display::create(800, 600);
 
-  std::cout << "Testing Scoped Enums..." << std::endl;
+  std::cerr << "Testing Scoped Enums..." << std::endl;
+
+  // Wrap active screen to use as parent
+  lvgl::Object screen(lv_screen_active());
 
   {
-    lvgl::Button btn;
+    std::cerr << "Block 1 Start" << std::endl;
+    lvgl::Button btn(screen);
+    std::cerr << "Button created" << std::endl;
     btn.set_size(100, 50)
         .set_bg_opa(lvgl::Opacity::Cover)
         .set_border_opa(lvgl::Opacity::Opa50)
         .set_border_side(lvgl::BorderSide::Bottom);
+    std::cerr << "Button styled" << std::endl;
 
     // Verify
     lv_obj_t* obj = btn.raw();
@@ -27,21 +36,93 @@ int main() {
     assert(lv_obj_get_style_border_opa(obj, LV_PART_MAIN) == LV_OPA_50);
     assert(lv_obj_get_style_border_side(obj, LV_PART_MAIN) ==
            LV_BORDER_SIDE_BOTTOM);
+    std::cerr << "Block 1 Done" << std::endl;
   }
 
   {
-    lvgl::Label label;
+    std::cerr << "Block 2 Start" << std::endl;
+    lvgl::Label label(screen);
+    std::cerr << "Label created" << std::endl;
     label.set_text("Hello");
+    std::cerr << "Label text set" << std::endl;
     label.set_text_align(lvgl::TextAlign::Center);
+    std::cerr << "Label align set" << std::endl;
     label.set_text_opa(lvgl::Opacity::Opa80);
+    std::cerr << "Label opa set" << std::endl;
 
     // Verify
     lv_obj_t* obj = label.raw();
     assert(lv_obj_get_style_text_align(obj, LV_PART_MAIN) ==
            LV_TEXT_ALIGN_CENTER);
     assert(lv_obj_get_style_text_opa(obj, LV_PART_MAIN) == LV_OPA_80);
+    std::cerr << "Label Basic Done" << std::endl;
   }
 
-  std::cout << "[SUCCESS] Scoped Enums validated." << std::endl;
+  {
+    lvgl::Object obj(&screen);
+    // Layout
+    obj.set_flex_flow(lvgl::FlexFlow::Row);
+    obj.set_flex_align(lvgl::FlexAlign::Center, lvgl::FlexAlign::SpaceEvenly,
+                       lvgl::FlexAlign::Start);
+    obj.set_scrollbar_mode(lvgl::ScrollbarMode::Auto);
+
+    // Verify Layout
+    assert(lv_obj_get_style_flex_flow(obj.raw(), LV_PART_MAIN) ==
+           LV_FLEX_FLOW_ROW);
+    assert(lv_obj_get_style_flex_main_place(obj.raw(), LV_PART_MAIN) ==
+           LV_FLEX_ALIGN_CENTER);
+    assert(lv_obj_get_scrollbar_mode(obj.raw()) == LV_SCROLLBAR_MODE_AUTO);
+    std::cerr << "Object Layout Done" << std::endl;
+  }
+
+  {
+    std::cerr << "Arc Start" << std::endl;
+    lvgl::Arc arc(screen);
+    arc.set_mode(lvgl::ArcMode::Reverse);
+    assert(lv_arc_get_mode(arc.raw()) == LV_ARC_MODE_REVERSE);
+    std::cerr << "Arc Done" << std::endl;
+  }
+
+  {
+    std::cerr << "Bar Start" << std::endl;
+    lvgl::Bar bar(screen);
+    bar.set_mode(lvgl::BarMode::Range);
+    assert(lv_bar_get_mode(bar.raw()) == LV_BAR_MODE_RANGE);
+    std::cerr << "Bar Done" << std::endl;
+  }
+
+  {
+    std::cerr << "Slider Start" << std::endl;
+    lvgl::Slider slider(screen);
+    slider.set_mode(lvgl::SliderMode::Symmetrical);
+    // Note: Slider implementation validation depends on internal storage or
+    // behavior, checking mode getter if available or just compilation.
+    // lv_slider_get_mode doesn't exist in v8/v9 API directly usually, it shares
+    // with Bar?
+    assert(lv_bar_get_mode(slider.raw()) == LV_BAR_MODE_SYMMETRICAL);
+    std::cerr << "Slider Done" << std::endl;
+  }
+
+  {
+    std::cerr << "Label Long Mode Start" << std::endl;
+    lvgl::Label label(screen);
+    std::cerr << "Label2 created" << std::endl;
+    label.set_long_mode(lvgl::LabelLongMode::Dot);
+    std::cerr << "Label2 set_mode" << std::endl;
+    assert(lv_label_get_long_mode(label.raw()) == LV_LABEL_LONG_DOT);
+    std::cerr << "Label Long Mode Done" << std::endl;
+  }
+
+  {
+    std::cerr << "Event Start" << std::endl;
+    // EventCode compilation check with AddEventCb
+    lvgl::Object obj(&screen);
+    obj.add_event_cb(lvgl::EventCode::Clicked, [](lvgl::Event& e) { (void)e; });
+    // Run an event?
+    lv_obj_send_event(obj.raw(), LV_EVENT_CLICKED, nullptr);
+    std::cerr << "Event Done" << std::endl;
+  }
+
+  std::cerr << "[SUCCESS] Scoped Enums validated." << std::endl;
   return 0;
 }

--- a/widgets/arc.h
+++ b/widgets/arc.h
@@ -54,6 +54,9 @@ class Arc : public Widget<Arc> {
    * @param type Mode (e.g., `LV_ARC_MODE_NORMAL`).
    */
   Arc& set_mode(lv_arc_mode_t type);
+  Arc& set_mode(ArcMode type) {
+    return set_mode(static_cast<lv_arc_mode_t>(type));
+  }
 
   /**
    * @brief Set the current value.

--- a/widgets/bar.h
+++ b/widgets/bar.h
@@ -78,6 +78,9 @@ class Bar : public Widget<Bar> {
    * @param mode Bar mode (`LV_BAR_MODE_NORMAL` or `LV_BAR_MODE_RANGE`).
    */
   Bar& set_mode(lv_bar_mode_t mode);
+  Bar& set_mode(BarMode mode) {
+    return set_mode(static_cast<lv_bar_mode_t>(mode));
+  }
 
   /**
    * @brief Set the orientation of the bar.

--- a/widgets/chart.h
+++ b/widgets/chart.h
@@ -51,6 +51,9 @@ class Chart : public Widget<Chart> {
   explicit Chart(lv_obj_t* obj, Ownership ownership = Ownership::Default);
 
   Chart& set_type(lv_chart_type_t type);
+  Chart& set_type(ChartType type) {
+    return set_type(static_cast<lv_chart_type_t>(type));
+  }
   Chart& set_point_count(uint32_t cnt);
   Chart& set_axis_range(lv_chart_axis_t axis, int32_t min, int32_t max);
   Chart& set_div_line_count(uint32_t hdiv, uint32_t vdiv);

--- a/widgets/keyboard.h
+++ b/widgets/keyboard.h
@@ -30,6 +30,9 @@ class Keyboard : public Widget<Keyboard> {
   Keyboard& set_textarea(lv_obj_t* ta);
   Keyboard& set_textarea(Object& ta);
   Keyboard& set_mode(lv_keyboard_mode_t mode);
+  Keyboard& set_mode(KeyboardMode mode) {
+    return set_mode(static_cast<lv_keyboard_mode_t>(mode));
+  }
   Keyboard& set_popovers(bool en);
   Keyboard& set_map(lv_keyboard_mode_t mode, const char* const map[],
                     const lv_buttonmatrix_ctrl_t ctrl_map[]);

--- a/widgets/label.h
+++ b/widgets/label.h
@@ -76,6 +76,9 @@ class Label : public Widget<Label> {
    * @param mode The long mode to set.
    */
   Label& set_long_mode(lv_label_long_mode_t mode);
+  Label& set_long_mode(LabelLongMode mode) {
+    return set_long_mode(static_cast<lv_label_long_mode_t>(mode));
+  }
 
   /**
    * @brief Get the long mode behavior.

--- a/widgets/slider.h
+++ b/widgets/slider.h
@@ -51,6 +51,9 @@ class Slider : public Bar {
   Slider& set_start_value(int32_t value, lv_anim_enable_t anim = LV_ANIM_ON);
   Slider& set_range(int32_t min, int32_t max);
   Slider& set_mode(lv_bar_mode_t mode);
+  Slider& set_mode(SliderMode mode) {
+    return set_mode(static_cast<lv_bar_mode_t>(mode));
+  }
 
   /**
    * @brief Set the value of the left knob (for range slider).


### PR DESCRIPTION
Closes #93, #94, #95, #96. Implements scoped enum overloads for Layout, Scroll, and Widget modes. Checks for Object validity in destructor.