### PR TITLE
feat(enums): Add IndevState and IndevType scoped enums

### DIFF
--- a/indev/input_device.cpp
+++ b/indev/input_device.cpp
@@ -91,8 +91,9 @@ void InputDevice::set_type(lv_indev_type_t type) {
 
 // ... wrapped methods ...
 
-lv_indev_type_t InputDevice::get_type() {
-  return indev_ ? lv_indev_get_type(indev_) : LV_INDEV_TYPE_NONE;
+IndevType InputDevice::get_type() const {
+  return indev_ ? static_cast<IndevType>(lv_indev_get_type(indev_))
+                : IndevType::None;
 }
 
 void InputDevice::reset(Object* obj) {
@@ -111,8 +112,9 @@ void InputDevice::read() {
   if (indev_) lv_indev_read(indev_);
 }
 
-lv_indev_state_t InputDevice::get_state() {
-  return indev_ ? lv_indev_get_state(indev_) : LV_INDEV_STATE_RELEASED;
+IndevState InputDevice::get_state() const {
+  return indev_ ? static_cast<IndevState>(lv_indev_get_state(indev_))
+                : IndevState::Released;
 }
 
 void InputDevice::get_point(lv_point_t* point) {

--- a/indev/input_device.h
+++ b/indev/input_device.h
@@ -6,6 +6,7 @@
 
 // #include "../core/group.h"   // Removed: cleanup
 #include "../core/object.h"  // IWYU pragma: export
+#include "../misc/enums.h"   // For IndevType, IndevState
 #include "lvgl.h"            // IWYU pragma: export
 
 namespace lvgl {
@@ -37,14 +38,14 @@ class InputDevice {
   void set_type(lv_indev_type_t type);
 
   // Methods
-  lv_indev_type_t get_type();
+  IndevType get_type() const;
   void reset(Object* obj);
   void stop_processing();
   void enable(bool en);
   void read();  // Manual trigger
 
   // Data Access
-  lv_indev_state_t get_state();
+  IndevState get_state() const;
   void get_point(lv_point_t* point);
   lv_dir_t get_gesture_dir();
   uint32_t get_key();

--- a/misc/enums.h
+++ b/misc/enums.h
@@ -445,6 +445,29 @@ enum class Key : uint8_t {
   End = LV_KEY_END,
 };
 
+// ============================================================================
+// Input Device Enums
+// ============================================================================
+
+/**
+ * @brief Wrapper for lv_indev_state_t.
+ */
+enum class IndevState : uint8_t {
+  Released = LV_INDEV_STATE_RELEASED,
+  Pressed = LV_INDEV_STATE_PRESSED,
+};
+
+/**
+ * @brief Wrapper for lv_indev_type_t.
+ */
+enum class IndevType : uint8_t {
+  None = LV_INDEV_TYPE_NONE,
+  Pointer = LV_INDEV_TYPE_POINTER,
+  Keypad = LV_INDEV_TYPE_KEYPAD,
+  Button = LV_INDEV_TYPE_BUTTON,
+  Encoder = LV_INDEV_TYPE_ENCODER,
+};
+
 /**
  * @brief Wrapper for lv_roller_mode_t.
  */

--- a/tests/test_input_device.cpp
+++ b/tests/test_input_device.cpp
@@ -17,7 +17,7 @@ void setup() { lv_init(); }
 void test_pointer_creation() {
   std::cout << "Testing PointerInput creation..." << std::endl;
   auto ptr = lvgl::PointerInput::create();
-  assert(ptr.get_type() == LV_INDEV_TYPE_POINTER);
+  assert(ptr.get_type() == lvgl::IndevType::Pointer);
   assert(ptr.raw() != nullptr);
   std::cout << "PointerInput creation passed." << std::endl;
 }
@@ -33,7 +33,7 @@ void test_callback_dispatch() {
   ptr.set_read_cb([](lv_indev_data_t* data) {
     callback_called = true;
     callback_count++;
-    data->state = LV_INDEV_STATE_PRESSED;
+    data->state = static_cast<lv_indev_state_t>(lvgl::IndevState::Pressed);
   });
 
   // Manually trigger a read (which calls the trampoline -> lambda)
@@ -64,17 +64,17 @@ void test_subclasses() {
 
   {
     auto keypad = lvgl::KeypadInput::create();
-    assert(keypad.get_type() == LV_INDEV_TYPE_KEYPAD);
+    assert(keypad.get_type() == lvgl::IndevType::Keypad);
   }  // Should delete keypad here
 
   {
     auto encoder = lvgl::EncoderInput::create();
-    assert(encoder.get_type() == LV_INDEV_TYPE_ENCODER);
+    assert(encoder.get_type() == lvgl::IndevType::Encoder);
   }  // Should delete encoder here
 
   {
     auto btn = lvgl::ButtonInput::create();
-    assert(btn.get_type() == LV_INDEV_TYPE_BUTTON);
+    assert(btn.get_type() == lvgl::IndevType::Button);
 
     std::vector<lv_point_t> points = {{10, 10}, {50, 50}};
     btn.set_points(points);


### PR DESCRIPTION
## Summary
Fixes #111

Adds  and  scoped enums to provide idiomatic C++ type-safe alternatives to raw LVGL constants.

## Changes
- Add `IndevState` enum (`Released`, `Pressed`) to `misc/enums.h`
- Add `IndevType` enum (`None`, `Pointer`, `Keypad`, `Button`, `Encoder`) to `misc/enums.h`
- Update `InputDevice::get_type()` and `get_state()` to return scoped enums
- Update `test_input_device.cpp` to use idiomatic enums

## Before (raw constants)
```cpp
assert(ptr.get_type() == LV_INDEV_TYPE_POINTER);
data->state = LV_INDEV_STATE_PRESSED;
```

## After (idiomatic)
```cpp
assert(ptr.get_type() == lvgl::IndevType::Pointer);
data->state = static_cast<lv_indev_state_t>(lvgl::IndevState::Pressed);
```

## Verification
- `test_input_device` builds and passes