### PR TITLE
fix(enums): Remove duplicate DisplayRotation enum

### DIFF
--- a/misc/enums.h
+++ b/misc/enums.h
@@ -554,16 +554,6 @@ enum class ColorFormat : uint8_t {
 };
 
 /**
- * @brief Wrapper for lv_display_rotation_t.
- */
-enum class DisplayRotation : uint8_t {
-  Rotation0 = LV_DISPLAY_ROTATION_0,
-  Rotation90 = LV_DISPLAY_ROTATION_90,
-  Rotation180 = LV_DISPLAY_ROTATION_180,
-  Rotation270 = LV_DISPLAY_ROTATION_270,
-};
-
-/**
  * @brief Wrapper for lv_anim_enable_t.
  */
 enum class AnimEnable : uint8_t {


### PR DESCRIPTION
## Summary
Removes duplicate DisplayRotation enum from misc/enums.h that was incorrectly added in PR #114.

## Issue
Display::Rotation already exists in display/display.h as a class-scoped enum, following the correct pattern per Issue #115.

## Scoping Principle
- Class-scoped: For enums tightly coupled to a single class (e.g., Display::Rotation)
- Namespace-scoped: For shared enums used across multiple classes (e.g., lvgl::Align)

## Changes
- Remove DisplayRotation enum from misc/enums.h (10 lines)

## Related
- Issue #115 (Class-scoped widget enums)
- PR #114 (Added core enums - this PR reconciles it)