### PR TITLE
feat(widgets): Add ChartCursor and ScaleSection proxies

### DIFF
--- a/widgets/chart.cpp
+++ b/widgets/chart.cpp
@@ -102,6 +102,52 @@ void Chart::refresh() {
   if (obj_) lv_chart_refresh(obj_);
 }
 
+// --- ChartCursor ---
+
+void ChartCursor::set_pos(lv_point_t pos) {
+  if (chart_ && chart_->raw() && cursor_) {
+    lv_chart_set_cursor_pos(chart_->raw(), cursor_, &pos);
+  }
+}
+
+void ChartCursor::set_pos_x(int32_t x) {
+  if (chart_ && chart_->raw() && cursor_) {
+    lv_chart_set_cursor_pos_x(chart_->raw(), cursor_, x);
+  }
+}
+
+void ChartCursor::set_pos_y(int32_t y) {
+  if (chart_ && chart_->raw() && cursor_) {
+    lv_chart_set_cursor_pos_y(chart_->raw(), cursor_, y);
+  }
+}
+
+void ChartCursor::set_point(ChartSeries& series, uint32_t point_id) {
+  if (chart_ && chart_->raw() && cursor_ && series.raw()) {
+    lv_chart_set_cursor_point(chart_->raw(), cursor_, series.raw(), point_id);
+  }
+}
+
+lv_point_t ChartCursor::get_point() const {
+  if (chart_ && chart_->raw() && cursor_) {
+    return lv_chart_get_cursor_point(chart_->raw(), cursor_);
+  }
+  return {0, 0};
+}
+
+ChartCursor Chart::add_cursor(lv_color_t color, lv_dir_t dir) {
+  if (obj_) {
+    return ChartCursor(this, lv_chart_add_cursor(obj_, color, dir));
+  }
+  return ChartCursor(this, nullptr);
+}
+
+void Chart::remove_cursor(ChartCursor cursor) {
+  if (obj_ && cursor.raw()) {
+    lv_chart_remove_cursor(obj_, cursor.raw());
+  }
+}
+
 }  // namespace lvgl
 
 #endif  // LV_USE_CHART

--- a/widgets/chart.h
+++ b/widgets/chart.h
@@ -43,6 +43,46 @@ class ChartSeries {
   lv_chart_series_t* series_;
 };
 
+/**
+ * @brief Wrapper for a chart cursor.
+ */
+class ChartCursor {
+ public:
+  ChartCursor(Chart* chart, lv_chart_cursor_t* cursor)
+      : chart_(chart), cursor_(cursor) {}
+
+  /**
+   * @brief Set the cursor position using a point.
+   */
+  void set_pos(lv_point_t pos);
+
+  /**
+   * @brief Set the cursor X position.
+   */
+  void set_pos_x(int32_t x);
+
+  /**
+   * @brief Set the cursor Y position.
+   */
+  void set_pos_y(int32_t y);
+
+  /**
+   * @brief Set the cursor to a specific point on a series.
+   */
+  void set_point(ChartSeries& series, uint32_t point_id);
+
+  /**
+   * @brief Get the current cursor point position.
+   */
+  lv_point_t get_point() const;
+
+  lv_chart_cursor_t* raw() const { return cursor_; }
+
+ private:
+  Chart* chart_;
+  lv_chart_cursor_t* cursor_;
+};
+
 class Chart : public Widget<Chart> {
  public:
   /**
@@ -87,8 +127,14 @@ class Chart : public Widget<Chart> {
   Type get_type() const;
   uint32_t get_point_count() const;
 
+  // Series management
   ChartSeries add_series(lv_color_t color, Axis axis);
   void remove_series(ChartSeries series);
+
+  // Cursor management
+  ChartCursor add_cursor(lv_color_t color, lv_dir_t dir);
+  void remove_cursor(ChartCursor cursor);
+
   void refresh();
 };
 

--- a/widgets/scale.cpp
+++ b/widgets/scale.cpp
@@ -103,6 +103,27 @@ int32_t Scale::get_range_max_value() {
   return obj_ ? lv_scale_get_range_max_value(obj_) : 0;
 }
 
+// --- ScaleSection ---
+
+void ScaleSection::set_range(int32_t min, int32_t max) {
+  if (section_) {
+    lv_scale_section_set_range(section_, min, max);
+  }
+}
+
+void ScaleSection::set_style(lv_part_t part, lv_style_t* style) {
+  if (section_) {
+    lv_scale_section_set_style(section_, part, style);
+  }
+}
+
+ScaleSection Scale::add_section() {
+  if (obj_) {
+    return ScaleSection(this, lv_scale_add_section(obj_));
+  }
+  return ScaleSection(this, nullptr);
+}
+
 }  // namespace lvgl
 
 #endif  // LV_USE_SCALE

--- a/widgets/scale.h
+++ b/widgets/scale.h
@@ -20,6 +20,33 @@
  */
 namespace lvgl {
 
+class Scale;  // Forward declaration
+
+/**
+ * @brief Wrapper for a scale section.
+ */
+class ScaleSection {
+ public:
+  ScaleSection(Scale* scale, lv_scale_section_t* section)
+      : scale_(scale), section_(section) {}
+
+  /**
+   * @brief Set the range of values for this section.
+   */
+  void set_range(int32_t min, int32_t max);
+
+  /**
+   * @brief Set the style for a specific part of this section.
+   */
+  void set_style(lv_part_t part, lv_style_t* style);
+
+  lv_scale_section_t* raw() const { return section_; }
+
+ private:
+  Scale* scale_;
+  lv_scale_section_t* section_;
+};
+
 class Scale : public Widget<Scale> {
  public:
   Scale();
@@ -48,6 +75,9 @@ class Scale : public Widget<Scale> {
   uint32_t get_angle_range();
   int32_t get_range_min_value();
   int32_t get_range_max_value();
+
+  // Section management
+  ScaleSection add_section();
 };
 
 }  // namespace lvgl


### PR DESCRIPTION
## Summary

Issue #126: Widget Proxies

This PR adds proxy classes for Chart cursors and Scale sections.

### ChartCursor Proxy

- `ChartCursor::set_pos(lv_point_t)` - Set cursor position
- `ChartCursor::set_pos_x(int32_t)` - Set X position
- `ChartCursor::set_pos_y(int32_t)` - Set Y position
- `ChartCursor::set_point(ChartSeries&, uint32_t)` - Set cursor to series point
- `ChartCursor::get_point()` - Get current cursor position
- `Chart::add_cursor()` / `remove_cursor()` factory methods

### ScaleSection Proxy

- `ScaleSection::set_range(int32_t, int32_t)` - Set section value range
- `ScaleSection::set_style(lv_part_t, lv_style_t*)` - Set section part style
- `Scale::add_section()` factory method

## Testing

All 30 tests pass.

Closes #126