### PR TITLE
docs: Purge 'God Object' terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | **Typing** | `void*` context pointers. Unsafe casts. | **Strongly Typed**. `Button`, `Label`, `Slider` classes. |
 | **Events** | `void event_cb(lv_event_t*)` with switches. | **Lambdas**: `btn.add_event_cb(..., [=](Event e) { ... })`. |
 | **Styles** | Verbose: `lv_style_set_bg_color(&style, ...)` | **Fluent**: `Style().bg_color(Red).radius(5)` |
-| **Safety** | "God Object" `lv_obj_t` has all API methods. | **CRTP Mixins**. Only exposing valid methods for each widget. |
+| **Safety** | "Monolithic Object" `lv_obj_t` has all API methods. | **CRTP Mixins**. Only exposing valid methods for each widget. |
 
 ---
 
@@ -135,7 +135,7 @@ The library prevents memory leaks by strictly defining who owns the LVGL object.
 
 ### 2. Widget Type Hierarchy
 
-We avoid the "God Object" anti-pattern. `lvgl::Object` is the base, but functionality is composed via **CRTP Mixins**:
+We avoid the "Monolithic Object" anti-pattern. `lvgl::Object` is the base, but functionality is composed via **CRTP Mixins**:
 
 *   **`Positionable<T>`**: `set_x`, `set_y`, `align`, `center`, `set_size`...
 *   **`Stylable<T>`**: `add_style`, `set_bg_color` (local), `set_border_width`...

--- a/design/README.md
+++ b/design/README.md
@@ -6,7 +6,7 @@ This directory serves as the architectural knowledge base for `lvgl_cpp`.
 
 Fundamental design patterns and system-level components.
 
-*   **[Core/Object System](README.md)**: (This file) Overview of God Object avoidance, Mixins, and CRTP.
+*   **[Core/Object System](README.md)**: (This file) Overview of Monolithic Object avoidance, Mixins, and CRTP.
 *   **[Issue #61: Standardization](issue_61_standardization.md)**: The "One Constructor to Rule Them All" pattern for widgets.
 *   **[Callback Utilities](callback_utilities.md)**: Design of the `CallbackProxy` and `Event` functional wrappers.
 *   **[Style System](core/STYLES.md)**: Detailed design of the Fluent Style Builder API.

--- a/design/ROADMAP_V2.md
+++ b/design/ROADMAP_V2.md
@@ -1,7 +1,7 @@
 # lvgl_cpp Refactoring Roadmap v2.0
 
 ## 1. Executive Summary
-The primary goal of the v0.2.0 refactoring—standardizing the widget architecture and eliminating "God Object" inheritance—is **100% complete**. Every widget now inherits from the CRTP `Widget<T>` template and utilizes shared mixins for core functionality (Position, Size, Style, Events).
+The primary goal of the v0.2.0 refactoring—standardizing the widget architecture and eliminating "Monolithic Object" inheritance—is **100% complete**. Every widget now inherits from the CRTP `Widget<T>` template and utilizes shared mixins for core functionality (Position, Size, Style, Events).
 
 The focus now shifts from **Structural Migration** to **Behavioral idiomaticness** and **System Management**.
 


### PR DESCRIPTION
## Summary

Replaced the deprecated term 'God Object' with the standard 'Monolithic Object' in:
- `README.md`
- `design/README.md`
- `design/ROADMAP_V2.md`

This aligns with the new style rule added to `GEMINI.md`.