### PR TITLE
feat: Idiomatic Style Selectors & Typed Animation Callbacks

### DIFF
--- a/design/idiomatic_gap_analysis.md
+++ b/design/idiomatic_gap_analysis.md
@@ -1,0 +1,148 @@
+# Idiomatic Gap Analysis: Style Selectors & Typed Callbacks
+
+## 1. Executive Summary
+
+This document addresses two critical ergonomic gaps in `lvgl_cpp` identified in Issues #168 and #170. These gaps represent friction points where the C++ abstraction leaks, forcing users to interact with raw C types (`void*`, `lv_style_selector_t`) or perform unsafe casts.
+
+**Identified Issues:**
+1.  **Style Selector Composition (Issue #168):** Users cannot idiomatically combine `Part` and `State` enums (e.g., `Part::Indicator | State::Checked`) because they are scoped enums with different underlying types.
+2.  **Callback Type Safety (Issue #170):** Callbacks in `Animation` (and potentially other subsystems) expose `void*` context pointers, requiring users to manually cast and wrap them into C++ `Object` instances.
+
+**Root Cause:**
+While `lvgl_cpp` successfully encapsulates LVGL's structural elements (Widgets, Objects), it falls short in **interoperability ergonomics** (combining enums) and **behavioral abstraction** (marshalling callback arguments).
+
+---
+
+## 2. Issue #168: Idiomatic Style Selectors
+
+### 2.1 Problem Analysis
+
+The `lvgl::Part` and `lvgl::State` enums are strictly typed `enum class` wrappers.
+- `Part` wraps `lv_part_t` (uint32_t)
+- `State` wraps `lv_state_t` (uint16_t)
+
+LVGL's C API expects `lv_style_selector_t` which is semantically `part | state`.
+Currently, users must write:
+```cpp
+// Current (Noisy, Unsafe)
+obj.style(static_cast<lv_style_selector_t>(Part::Indicator) | 
+          static_cast<lv_style_selector_t>(State::Checked))
+   .bg_color(Color::Red);
+```
+
+### 2.2 Proposed Solution: Operator Overloading
+
+The `Part | State` combination is the **only significant instance** in the LVGL API where two distinct enum types are designed to be bitwise-combined. Other bitmasks (like `ObjFlag` or `TextDecor`) combine values of the *same* type.
+
+We will implement `operator|` overloads that seamlessly combine these types into a type-safe selector.
+
+**Design:**
+
+In `misc/enums.h`:
+```cpp
+// forward declaration
+enum class Part : uint32_t;
+enum class State : uint16_t;
+
+// 1. Part | State
+inline lv_style_selector_t operator|(Part p, State s) {
+    return static_cast<lv_style_selector_t>(p) | static_cast<lv_style_selector_t>(s);
+}
+
+// 2. State | Part (Commutative)
+inline lv_style_selector_t operator|(State s, Part p) {
+    return static_cast<lv_style_selector_t>(p) | static_cast<lv_style_selector_t>(s);
+}
+
+// 3. Part | Part (mutually exclusive usually, but valid for ANY)
+inline lv_style_selector_t operator|(Part p1, Part p2) {
+    return static_cast<lv_style_selector_t>(p1) | static_cast<lv_style_selector_t>(p2);
+}
+```
+
+This allows:
+```cpp
+// Proposed (Fluent)
+obj.style(Part::Indicator | State::Checked).bg_color(Color::Red);
+```
+
+### 2.3 Impact
+- **Ergonomics:** Removes casting noise.
+- **Safety:** Ensures only valid enum combinations result in a selector.
+- **Migration:** Non-breaking addition.
+
+---
+
+## 3. Issue #170: Typed Callbacks in Animation
+
+### 3.1 Problem Analysis
+
+The `Animation` class relies on `ExecCallback` defined as `std::function<void(void*, int32_t)>`.
+When animating a C++ `Object`, the `void*` is the raw `lv_obj_t*`.
+Users must manually wrap it:
+```cpp
+// Current (Friction)
+anim.set_exec_cb([](void* var, int32_t v) {
+    lvgl::Object obj(static_cast<lv_obj_t*>(var)); // Unmanaged wrapper
+    obj.style().translate_y(v);
+});
+```
+
+### 3.2 Proposed Solution: Typed Trampoline
+
+We introduce a templated overload or specific `set_exec_cb` for `Object` types that performs the wrapping automatically.
+
+**Design:**
+
+In `misc/animation.h`:
+```cpp
+class Animation {
+public:
+    // ... existing ...
+
+    /**
+     * @brief Set a type-safe execution callback for Objects.
+     * The callback receives a temporary reference to an unmanaged Object wrapper.
+     */
+    using ObjectExecCallback = std::function<void(Object&, int32_t)>;
+    
+    Animation& set_exec_cb(ObjectExecCallback cb) {
+        // Capture user callback
+        auto trampoline = [cb](void* var, int32_t val) {
+            // Create temporary unmanaged wrapper
+            Object obj(static_cast<lv_obj_t*>(var), Object::Ownership::Unmanaged);
+            cb(obj, val);
+        };
+        return set_exec_cb(static_cast<ExecCallback>(trampoline));
+    }
+};
+```
+
+This allows:
+```cpp
+// Proposed (Fluent)
+anim.set_exec_cb([](Object& obj, int32_t v) {
+    obj.style().translate_y(v);
+});
+```
+
+### 3.3 Implementation Details
+- The existing `CallbackData` structure in `Animation` holds a `std::function<void(void*, int32_t)>`. The new method will simply wrap the user's typed lambda into this generic signature.
+- **Lifecycle Safety:** The `Object` wrapper created in the trampoline is `Ownership::Unmanaged`. It is strict generic wrapper around the pointer. It is valid only for the duration of the callback, which is correct.
+
+---
+
+## 4. Systemic Review
+
+This "marshall and wrap" pattern addresses the gap between C `void*` polymorphism and C++ strict typing.
+
+**Other candidates:**
+- **`InputDevice`**: If custom feedback callbacks are added, they should use `InputDevice&` not `lv_indev_t*`.
+- **`Group`**: Focus callbacks should receive `Object&` focused (already identified in strategic plan).
+- **`Event`**: The `Event` class already accesses the target via `get_target()`, which returns `Object*`. This is already consistent.
+
+## 5. Next Steps
+1.  Modify `misc/enums.h` to add `operator|` overloads.
+2.  Modify `misc/animation.h` to add `set_exec_cb(ObjectExecCallback)`.
+3.  Update `round_display_hello` example to use the new API to verify #170.
+4.  Update a test case to verify style selector combination for #168.

--- a/examples/esp32/round_display_hello/main/ui/hello_world.cpp
+++ b/examples/esp32/round_display_hello/main/ui/hello_world.cpp
@@ -40,7 +40,10 @@ void HelloWorld::load(lvgl::Display& display, const std::string& text,
   lvgl::Animation(label)
       .set_values(-50, 0)  // Start off-screen and slide to center
       .set_duration(2000)
-      .set_exec_cb(lvgl::Animation::Exec::Y())
+      .set_exec_cb([](lvgl::Object& obj, int32_t v) {
+        // Use new typed callback (Issue #170)
+        obj.set_y(v);
+      })
       .set_path_cb(lvgl::Animation::Path::EaseOut())
       .set_completed_cb([]() { ESP_LOGI("UI", "Animation completed!"); })
       .start();

--- a/misc/animation.cpp
+++ b/misc/animation.cpp
@@ -136,6 +136,17 @@ Animation& Animation::set_exec_cb(ExecCallback cb) {
   return *this;
 }
 
+Animation& Animation::set_exec_cb(ObjectExecCallback cb) {
+  // Trampoline to convert void* -> Object&
+  auto trampoline = [cb](void* var, int32_t v) {
+    if (var) {
+      Object obj(static_cast<lv_obj_t*>(var), Object::Ownership::Unmanaged);
+      cb(obj, v);
+    }
+  };
+  return set_exec_cb(static_cast<ExecCallback>(trampoline));
+}
+
 Animation& Animation::set_path_cb(PathCallback cb) {
   if (!user_data_) user_data_ = std::make_unique<CallbackData>();
   user_data_->path_cb = std::move(cb);

--- a/misc/animation.h
+++ b/misc/animation.h
@@ -46,6 +46,12 @@ class Animation {
 
  public:
   using ExecCallback = std::function<void(void*, int32_t)>;
+  /**
+   * @brief Type-safe execution callback for Objects.
+   * Receives a temporary unmanaged Object wrapper.
+   */
+  using ObjectExecCallback = std::function<void(Object&, int32_t)>;
+
   using PathCallback = std::function<int32_t(const lv_anim_t*)>;
   using CompletedCallback = std::function<void()>;
 
@@ -113,7 +119,30 @@ class Animation {
    *
    * @param cb The `std::function` callback.
    */
+  /**
+   * @brief Set a C++ execution callback (lambda/std::function).
+   *
+   * @example
+   * anim.set_exec_cb([](void* var, int32_t val) {
+   *     // Custom logic
+   * });
+   *
+   * @param cb The `std::function` callback.
+   */
   Animation& set_exec_cb(ExecCallback cb);
+
+  /**
+   * @brief Set a type-safe execution callback for Objects.
+   * Auto-wraps the void* var into a temporary `Object` wrapper.
+   *
+   * @example
+   * anim.set_exec_cb([](Object& obj, int32_t val) {
+   *     obj.style().translate_y(val);
+   * });
+   *
+   * @param cb The typed callback.
+   */
+  Animation& set_exec_cb(ObjectExecCallback cb);
 
   // ... (Exec struct omitted for brevity)
 

--- a/misc/enums.h
+++ b/misc/enums.h
@@ -1,6 +1,8 @@
 #ifndef LVGL_CPP_MISC_ENUMS_H_
 #define LVGL_CPP_MISC_ENUMS_H_
 
+#include <cstdint>
+
 #include "lvgl.h"
 
 namespace lvgl {
@@ -82,6 +84,7 @@ enum class State : uint16_t {
   Any = LV_STATE_ANY,
 };
 
+// Masking operators for State (State | State)
 inline State operator|(State lhs, State rhs) {
   return static_cast<State>(static_cast<lv_state_t>(lhs) |
                             static_cast<lv_state_t>(rhs));
@@ -104,6 +107,36 @@ inline State& operator|=(State& lhs, State rhs) {
 inline State& operator&=(State& lhs, State rhs) {
   lhs = lhs & rhs;
   return lhs;
+}
+
+// ============================================================================
+// Cross-Type Masking Operators (Part | State) -> lv_style_selector_t
+// See: https://github.com/pedapudi/lvgl_cpp/issues/168
+// ============================================================================
+
+/**
+ * @brief Combine Part and State into a style selector.
+ */
+inline lv_style_selector_t operator|(Part p, State s) {
+  return static_cast<lv_style_selector_t>(p) |
+         static_cast<lv_style_selector_t>(s);
+}
+
+/**
+ * @brief Combine State and Part into a style selector.
+ */
+inline lv_style_selector_t operator|(State s, Part p) {
+  return static_cast<lv_style_selector_t>(p) |
+         static_cast<lv_style_selector_t>(s);
+}
+
+/**
+ * @brief Combine Part and Part into a style selector.
+ * Rare, but useful for LV_PART_ANY or complex masking.
+ */
+inline lv_style_selector_t operator|(Part lhs, Part rhs) {
+  return static_cast<lv_style_selector_t>(lhs) |
+         static_cast<lv_style_selector_t>(rhs);
 }
 
 /**

--- a/tests/test_idiomatic_gap.cpp
+++ b/tests/test_idiomatic_gap.cpp
@@ -1,0 +1,78 @@
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+#include "../core/object.h"
+#include "../misc/animation.h"
+#include "../misc/enums.h"
+#include "lvgl.h"
+
+// Mock for testing without full display driver if possible,
+// otherwise this runs as a normal test in the suite.
+
+void test_style_selector_operators() {
+  std::cout << "Testing Style Selector Operators..." << std::endl;
+
+  // Test Part | State
+  lv_style_selector_t s1 = lvgl::Part::Indicator | lvgl::State::Checked;
+  assert((s1 & LV_PART_INDICATOR) && (s1 & LV_STATE_CHECKED));
+
+  // Test State | Part
+  lv_style_selector_t s2 = lvgl::State::Pressed | lvgl::Part::Main;
+  assert((s2 & LV_PART_MAIN) && (s2 & LV_STATE_PRESSED));
+
+  // Test Part | Part
+  lv_style_selector_t s3 = lvgl::Part::Items | lvgl::Part::Selected;
+  assert((s3 & LV_PART_ITEMS) && (s3 & LV_PART_SELECTED));
+
+  std::cout << "PASS: Style Selector Operators" << std::endl;
+}
+
+void test_animation_typed_callback() {
+  std::cout << "Testing Animation Typed Callback..." << std::endl;
+
+  // Create a dummy object
+  lvgl::Object obj(lv_screen_active(), lvgl::Object::Ownership::Unmanaged);
+  obj.set_x(0);
+
+  // Create an animation
+  lvgl::Animation anim(obj);
+  anim.set_values(0, 100);
+  anim.set_duration(100);
+
+  // Set typed callback
+  bool callback_called = false;
+  anim.set_exec_cb([&callback_called](lvgl::Object& target, int32_t val) {
+    callback_called = true;
+    target.set_x(val);  // Should work on the wrapper
+    assert(target.raw() != nullptr);
+  });
+
+  // Manually trigger the internal exec callback wrapper to verify it works
+  // We can't easily wait for LVGL timer in a unit test without a main loop,
+  // so we access the raw callback mechanisms or trust the wrapper logic.
+  // However, since we modified Animation::set_exec_cb to wrap the lambda,
+  // we can check if starting it sets the C callback.
+
+  anim.start();
+
+  // In a real integration test we'd let the loop run.
+  // Here we can at least assert that compilation works and the setup didn't
+  // crash.
+  std::cout << "PASS: Animation Typed Callback setup (Runtime verification "
+               "requires event loop)"
+            << std::endl;
+}
+
+int main() {
+  lv_init();
+
+  // Need a display for screens?
+  // lv_display_t * disp = lv_display_create(800, 480);
+  // lvgl::Display display(disp);
+
+  test_style_selector_operators();
+  test_animation_typed_callback();
+
+  return 0;
+}


### PR DESCRIPTION
Closes #168, Closes #170, Closes #171. Implements operator overloads for mixing Part and State enums, and adds a type-safe set_exec_cb for Animations.