### PR TITLE
docs: sync readme and migration guide

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -42,20 +42,14 @@ lvgl::Button btn; // Automatically uses lv_screen_active()
 lvgl::Button btn(parent_obj);
 ```
 
-### 3. Fluency
-Most setters now return `*this` typed to the specific class, allowing chaining.
+### 3. Fluency and Typed Properties
+Most setters now return `*this` typed to the specific class, allowing chaining. Additionally, raw C constants (macros) are being phased out in favor of C++ scoped enums.
 
 ```cpp
 lvgl::Button btn;
 btn.set_size(100, 50)
-   .center()
-   .add_flag(LV_OBJ_FLAG_CHECKABLE);
-```
-```cpp
-lvgl::Button btn;
-btn.set_size(100, 50)
-   .center()
-   .add_flag(LV_OBJ_FLAG_CHECKABLE);
+   .set_align(lvgl::Align::Center) // Use Align::Center enum
+   .add_flag(lvgl::ObjFlag::Checkable); // Use ObjFlag enum
 ```
 
 ### 4. Styles: Fluent Proxy API
@@ -93,10 +87,19 @@ public:
     }
 };
 ```
-### 4. Scoped Enums
-Use C++ Scoped Enums instead of raw macros for improved type safety.
+### 4. Scoped Enums (Strict Typing)
+Use C++ Scoped Enums instead of raw macros for improved type safety. Many methods that previously accepted both now strictly require the C++ enum.
 - `LV_STATE_PRESSED` -> `lvgl::State::Pressed`
 - `LV_PART_MAIN` -> `lvgl::Part::Main`
+- `LV_ALIGN_CENTER` -> `lvgl::Align::Center`
+- `LV_FLEX_FLOW_ROW` -> `lvgl::FlexFlow::Row`
+- `LV_FLEX_ALIGN_CENTER` -> `lvgl::FlexAlign::Center`
+- `LV_PALETTE_BLUE` -> `lvgl::Palette::Blue`
+
+Bitwise operations are supported for flag-like enums:
+```cpp
+btn.style().set_pad_all(10).add_state(State::Checked | State::Focused);
+```
 
 ### 5. Advanced Callbacks
 You can now use `std::function`, lambdas, and method binders directly.
@@ -106,8 +109,18 @@ btn.on_clicked([](lvgl::Event& e) {
 });
 ```
 
-### 6. New Manager Classes
+### 6. New Manager Classes and Proxies
 - **Screen**: `lvgl::Screen` for dedicated screen objects.
 - **Group**: `lvgl::Group` for input device groups.
-- **FileSystem**: `lvgl::File` and `lvgl::Directory` (stdio wrapper).
+- **FileSystem**: `lvgl::File` and `lvgl::Directory` (stdio wrapper) using `FsRes`, `FsMode`, and `FsWhence` enums.
 - **Images**: `lvgl::Image` with `ImageDescriptor` resource management.
+- **Proxies**: `style()`, `scroll()`, `layout()`, `tree()`, and `interaction()` offer specialized API sections without bloat.
+
+### 7. Core Object Lifecycle
+Core objects like `Display` and `InputDevice` now support **Move Semantics**. They are non-copyable to prevent accidental duplication of global handles but can be moved into storage.
+
+```cpp
+lvgl::Display disp = lvgl::Display::create(800, 480);
+std::vector<lvgl::Display> displays;
+displays.push_back(std::move(disp)); // Transfer ownership
+```

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ We avoid the "Monolithic Object" anti-pattern. `lvgl::Object` is the base, but f
 *   **`style()`**: Returns a `StyleProxy` for fluent local styling.
 *   **`scroll()`**: Returns a `ScrollProxy` for scrolling operations.
 *   **`layout()`**: Returns a `LayoutProxy` for flex/grid configuration.
+*   **`interaction()`**: Returns an `InteractionProxy` for gesture and group interaction management.
+*   **`tree()`**: Returns a `TreeProxy` for DOM-like navigation (parent/child/neighbors).
 
 This means `lvgl::Object` remains lightweight. To use button-specific features, you must use `lvgl::Button`.
 
@@ -180,6 +182,7 @@ group.add_obj(btn2);
 -   **Lottie Animations**: Render vector animations using `lvgl::Lottie`.
 -   **Vector Graphics**: Direct drawing API via `lvgl::VectorDraw` and `lvgl::VectorPath` (ThorVG).
 -   **System Abstractions**: `Display` management, `InputDevice` configuration (cursors), and `Theme` application.
+-   **Modernized Enums**: Full adoption of scoped enums for `Align`, `State`, `Part`, `Palette`, `FlexFlow`, etc.
 
 ---
 
@@ -191,7 +194,7 @@ The `design/` directory contains detailed architectural decision records (ADRs) 
 *   **[API Coverage Plan](design/api_coverage_plan.md)**: Verified feature matrix.
 *   **[Strategic Plan](design/strategic_improvement_plan.md)**: Deep dive into API coverage goals.
 *   **[Memory Analysis](design/memory_analysis.md)**: Performance overhead study.
-    *   *Result*: ~24 bytes overhead per C++ wrapper. No leaks (RAII).
+    *   *Result*: ~48 bytes overhead per C++ wrapper (on 64-bit). No leaks (RAII).
 *   **[Widget Standardization](design/issue_61_standardization.md)**: Constructor patterns.
 
 ---


### PR DESCRIPTION
Synchronizes documentation with the latest Platinum Bridge refinements, including scoped enum strict typing and move semantics.