### PR TITLE
Fixes for ESP32 Port: Event-driven Task Loop and build compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,8 @@ if(IDF_TARGET)
     )
     idf_component_register(SRCS ${SOURCES}
                         INCLUDE_DIRS "." ".."
-                        REQUIRES lvgl esp_lcd)
-    target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-cast-function-type)
+                        REQUIRES lvgl esp_lcd esp_timer driver)
+    target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-cast-function-type -Wno-missing-field-initializers)
     target_compile_features(${COMPONENT_LIB} PUBLIC cxx_std_20)
 else()
     project(lvgl_cpp)

--- a/display/drivers/esp32_rgb.cpp
+++ b/display/drivers/esp32_rgb.cpp
@@ -68,9 +68,10 @@ Esp32RgbDisplay::Esp32RgbDisplay(const Config& config) : config_(config) {
                         config_.render_mode);
 
   // 5. Register VSync Callback
-  esp_lcd_rgb_panel_event_callbacks_t cbs = {
-      .on_vsync = on_vsync_trampoline,
-  };
+  esp_lcd_rgb_panel_event_callbacks_t cbs;
+  memset(&cbs, 0, sizeof(cbs));
+  cbs.on_vsync = on_vsync_trampoline;
+
   esp_lcd_rgb_panel_register_event_callbacks(config.panel_handle, &cbs, this);
 
   // 6. Set Flush Callback
@@ -81,10 +82,10 @@ Esp32RgbDisplay::Esp32RgbDisplay(const Config& config) : config_(config) {
 
   // 7. Initialize GDMA for M2M copies if in Partial mode
   if (config_.render_mode == lvgl::Display::RenderMode::Partial) {
-    esp_async_memcpy_config_t m2m_config = {
-        .backlog = 128,  // Support up to 128 sequential row copies
-        .flags = 0,
-    };
+    async_memcpy_config_t m2m_config;
+    memset(&m2m_config, 0, sizeof(m2m_config));
+    m2m_config.backlog = 128;  // Support up to 128 sequential row copies
+
     esp_async_memcpy_install(&m2m_config,
                              reinterpret_cast<async_memcpy_handle_t*>(&m2m_));
     current_back_buffer_ = buf1_;

--- a/display/drivers/esp32_rgb.h
+++ b/display/drivers/esp32_rgb.h
@@ -4,6 +4,7 @@
 #include "lvgl_cpp/lvgl_cpp.h"
 
 #if __has_include("esp_lcd_panel_rgb.h")
+#include "esp_async_memcpy.h"
 #include "esp_lcd_panel_rgb.h"
 
 namespace lvgl {

--- a/utility/portable/esp32/port.cpp
+++ b/utility/portable/esp32/port.cpp
@@ -100,7 +100,10 @@ void Esp32Port::task_loop() {
 
     if (sleep_ms == 0) sleep_ms = 1;
     if (sleep_ms > 100) sleep_ms = 100;
-    vTaskDelay(pdMS_TO_TICKS(sleep_ms));
+
+    // Efficiently wait for the next timer or an external notification (e.g.
+    // touch/flush)
+    ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(sleep_ms));
   }
 
   ESP_LOGI(TAG, "LVGL Task Stopping");

--- a/utility/portable/esp32/port.h
+++ b/utility/portable/esp32/port.h
@@ -53,6 +53,34 @@ class Esp32Port {
     }
   }
 
+  /**
+   * @brief Get the underlying API lock (mutex).
+   * Useful for manual lock/unlock in legacy code.
+   */
+  SemaphoreHandle_t get_lock() const { return api_lock_; }
+
+  /**
+   * @brief Notify the LVGL task to wake up immediately.
+   */
+  void notify() {
+    if (task_handle_) {
+      xTaskNotifyGive(task_handle_);
+    }
+  }
+
+  /**
+   * @brief Notify the LVGL task from an ISR.
+   */
+  void notify_from_isr() {
+    if (task_handle_) {
+      BaseType_t high_task_wakeup = pdFALSE;
+      vTaskNotifyGiveFromISR(task_handle_, &high_task_wakeup);
+      if (high_task_wakeup) {
+        portYIELD_FROM_ISR();
+      }
+    }
+  }
+
  private:
   static void tick_inc_cb(void* arg);
   static void task_trampoline(void* arg);


### PR DESCRIPTION
Closes #194. 

This PR addresses several critical issues found during the integration of the `feat/native-double-buffering` branch:

- **Optimization**: Refactored the `Esp32Port` task loop to use FreeRTOS Task Notifications. It now sleeps efficiently using `ulTaskNotifyTake`, eliminating the fixed 10ms polling latency.
- **Waking API**: Added `notify()` and `notify_from_isr()` to allow external events (like touch or flush completion) to wake the UI task instantly.
- **Build Fixes**: 
    - Resolved missing `esp_async_memcpy.h` in `Esp32RgbDisplay`.
    - Corrected type names for ESP-IDF v5.x compatibility.
    - Used `memset` for struct initialization to satisfy strict compiler warnings.
- **Requirements**: Added `esp_timer` and `driver` to the component requirements.
- **Usability**: Exposed the recursive API mutex via `get_lock()` for better integration with legacy porting layers.