### PR TITLE
fix(animation): use lv_cubic_bezier for Bezier paths

### DIFF
--- a/misc/animation.cpp
+++ b/misc/animation.cpp
@@ -218,7 +218,12 @@ Animation::Path::Callback Animation::Path::Bezier(int32_t x1, int32_t y1,
   // To support custom Bezier curves, we'll use a lambda that captures the
   // coordinates.
   return [x1, y1, x2, y2](const lv_anim_t* a) -> int32_t {
-    return lv_cubic_bezier(lv_anim_path_linear(a), x1, y1, x2, y2);
+    // 1. Solve the Bezier y for progress x (0..1024)
+    int32_t step = lv_cubic_bezier(lv_anim_path_linear(a), x1, y1, x2, y2);
+
+    // 2. Map the solved 0..1024 step to the actual start..end range
+    // Using LVGL's map utility for consistency and integer safety
+    return lv_map(step, 0, 1024, a->start_value, a->end_value);
   };
 }
 


### PR DESCRIPTION
### Fix: Animation Path Regression in LVGL 9

This PR fixes a critical regression in `Animation::Path::Bezier` that caused custom easing curves to be flattened or ignored in LVGL 9.

#### Root Cause
1. **Wrong Helper**: The library was calling `lv_bezier3`, which in LVGL 9 is a specialized helper that hardcodes X-axis control points (341 and 683), ignoring custom input.
2. **Animation Contract**: In LVGL 9, path callbacks are expected to return the **final target value** (interpolated), whereas the previous implementation only returned the 0..1024 step. My previous attempt failed to account for this manual interpolation requirement.

#### Changes
- Switched from `lv_bezier3` to `lv_cubic_bezier` in `misc/animation.cpp`.
- Updated the lambda to perform manual linear interpolation between `a->start_value` and `a->end_value` based on the solved Bezier step.
- Included detailed documentation comments explaining this contract for future maintainers.

#### Verification
- Verified in a production-style workshop using SVG-derived cubic Bezier keySplines.
- Restore fluid, asymmetric easing for properties like rotation and translation.

Fixes #199